### PR TITLE
Find exact manifest id

### DIFF
--- a/CBXShell/cbxArchive.h
+++ b/CBXShell/cbxArchive.h
@@ -483,7 +483,7 @@ try {
 
 									// Find item tag in original opf file contents
 
-									posStart = xmlContent.find("id=\"" + coverId);
+									posStart = xmlContent.find("id=\"" + coverId + "\"");
 
 									if (posStart == std::string::npos) {
 										break;


### PR DESCRIPTION
If you have multiple manifest-ids with same (sub)string eg. "cover" and "cover.xhtml", darkthumbs takes the first, maybe wrong, id.